### PR TITLE
Fix missing space in party name

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -5,6 +5,12 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'scraped_page_archive/open-uri'
 
+class String
+  def tidy
+    gsub(/[[:space:]]+/, ' ').strip
+  end
+end
+
 def noko_for(url)
   Nokogiri::HTML(open(url).read)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -40,7 +40,7 @@ def scrape_list(url)
     data = {
       name: name,
       gender: gender,
-      faction: tds[2].text,
+      faction: tds[2].children.map(&:text).join(" ").tidy,
       image: URI.join(url, tds[0].css('img/@src').to_s).to_s,
       area: tds[3].text,
       term: 46,


### PR DESCRIPTION
 One party is displayed on the source page like so:

![screen shot 2016-10-17 at 10 18 57](https://cloud.githubusercontent.com/assets/4107953/19432158/31d9e602-9453-11e6-8878-310c14c1a2b7.png)

The line break caused a problem:

```
data[:faction]

=> NipponIshin no Kai
```

This commit fixes the missing space.

```
data[:faction]

=> Nippon Ishin no Kai
```

A step towards fixing: 

https://github.com/everypolitician/everypolitician-data/pull/18715
